### PR TITLE
Fix quick action layout

### DIFF
--- a/Flare Food/Views/Home/HomeView.swift
+++ b/Flare Food/Views/Home/HomeView.swift
@@ -309,40 +309,36 @@ struct HomeView: View {
             Text("Quick Actions")
                 .font(.headline)
             
-            VStack(spacing: 12) {
-                HStack(spacing: 12) {
-                    QuickActionButton(
-                        title: "Log Meal",
-                        icon: "plus.circle.fill",
-                        color: .orange,
-                        action: {
-                            showingMealLogger = true
-                        }
-                    )
-                    
-                    QuickActionButton(
-                        title: "Track Symptom",
-                        icon: "heart.text.square.fill",
-                        color: .pink,
-                        action: {
-                            showingSymptomTracker = true
-                        }
-                    )
+        let columns = [GridItem(.flexible()), GridItem(.flexible())]
+
+        LazyVGrid(columns: columns, spacing: 12) {
+            QuickActionButton(
+                title: "Log Meal",
+                icon: "plus.circle.fill",
+                color: .orange,
+                action: {
+                    showingMealLogger = true
                 }
-                
-                HStack(spacing: 12) {
-                    QuickActionButton(
-                        title: "Log Beverage",
-                        icon: "drop.fill",
-                        color: .blue,
-                        action: {
-                            showingBeverageLogger = true
-                        }
-                    )
-                    
-                    Spacer()
+            )
+
+            QuickActionButton(
+                title: "Track Symptom",
+                icon: "heart.text.square.fill",
+                color: .pink,
+                action: {
+                    showingSymptomTracker = true
                 }
-            }
+            )
+
+            QuickActionButton(
+                title: "Log Beverage",
+                icon: "drop.fill",
+                color: .blue,
+                action: {
+                    showingBeverageLogger = true
+                }
+            )
+        }
         }
     }
     


### PR DESCRIPTION
## Summary
- align quick action buttons using a grid

## Testing
- `xcodebuild test -project "Flare Food.xcodeproj" -scheme "Flare Food" -destination 'platform=iOS Simulator,name=iPhone 15' -enableCodeCoverage YES` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684353e8a948832c934be2f9755e402b